### PR TITLE
include remote site, v0.1.8

### DIFF
--- a/client/assets.coffee
+++ b/client/assets.coffee
@@ -7,11 +7,13 @@ expand = (text)->
 
 context = ($item) ->
   sites = [location.host]
+  if remote = $item.parents('.page').data('site')
+    unless remote == location.host
+      sites.push remote
   journal = $item.parents('.page').data('data').journal
   for action in journal.slice(0).reverse()
     if action.site? and not sites.includes(action.site)
       sites.push action.site
-  console.log 'context', sites
   sites
 
 fetch = ($report, assets, remote) ->

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wiki-plugin-assets",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "Federated Wiki - Assets Plugin",
   "keywords": [
     "assets",


### PR DESCRIPTION
For example `wiki.dbbs.co` is included here because the plugin exists on a page hosted on that site even though it is neither the origin nor mentioned in the journal.

![image](https://user-images.githubusercontent.com/12127/35195429-195bbeda-fe78-11e7-899b-8c931e3a3b25.png)
