### PR TITLE
Update server.coffee

### DIFF
--- a/server/server.coffee
+++ b/server/server.coffee
@@ -29,8 +29,7 @@ startServer = (params) ->
         return res.json {error, files}
 
   app.post '/plugin/assets/upload', (req, res) ->
-    return res.status(401).send("must login") unless req.session?.passport?.user || req.session?.email || req.session?.friend
-    return res.status(401).send("must be owner") unless app.securityhandler.isAuthorized(req)
+    return res.status(401).send("must be logged in owner") unless app.securityhandler.isAuthorized(req)
     form = new (formidable.IncomingForm)
     form.multiples = true
     form.uploadDir = "#{argv.assets}"


### PR DESCRIPTION
Remove login checks from upload validation logic.

The removed checks were judged redundant and misfired when using security_legacy.
We can speculate that the additional checks were included to refine the error message.
This pull request combines the messaging, must be owner and logged in, into one message.
This isn't strictly true in the security_legacy case but we don't expect to ever deliver the message in that case.

Initial report:

<img width="711" alt="image" src="https://user-images.githubusercontent.com/12127/206871111-81e14ad1-2fb8-4477-9f7b-74fb53cb8515.png">