### PR TITLE
add asset index endpoint

### DIFF
--- a/server/server.coffee
+++ b/server/server.coffee
@@ -28,6 +28,17 @@ startServer = (params) ->
       async.filter names, isFile, (error, files) ->
         return res.json {error, files}
 
+  app.get '/plugin/assets/index', cors, (req, res) ->
+    walk = (root) ->
+      fs.readdirSync("#{argv.assets}/#{root}").flatMap (name) ->
+        path = "#{root}/#{name}"
+        stat = fs.statSync("#{argv.assets}/#{path}")
+        if stat.isDirectory()
+          return walk(path)
+        else
+          return {file:path,size:stat.size}
+    return res.json(walk(""))
+
   app.post '/plugin/assets/upload', (req, res) ->
     return res.status(401).send("must be logged in owner") unless app.securityhandler.isAuthorized(req)
     form = new (formidable.IncomingForm)


### PR DESCRIPTION
This is a simple approach to facilitating retrieval of assets by providing an index.

```
curl -s http://ward.dojo.fed.wiki/plugin/assets/index | jq .
```
We have discussed more helpful ways to transfer whole sites between servers but this will enable a colleague in the process right now to improve their methods and offer additional advice on end user needs in this regard.

Perhaps we should provide some restrictions, like maybe requiring owner login?